### PR TITLE
feat: add response in "delete user" views

### DIFF
--- a/transbank-sdk-dotnet-core-rest-example/Views/oneclick_mall/delete.cshtml
+++ b/transbank-sdk-dotnet-core-rest-example/Views/oneclick_mall/delete.cshtml
@@ -1,4 +1,4 @@
-﻿ @{Html.RenderPartial("~/Views/Shared/navbar-oneclick.cshtml");}
+﻿    @{Html.RenderPartial("~/Views/Shared/navbar-oneclick.cshtml");}
 
     <div class="row">
         <div class="col">
@@ -39,7 +39,7 @@
     </div>
     <div class="col-6">
         <h4>Respuesta</h4>
-        En caso de éxito Transbank responderá con un true. En el caso de no encontrarse el userName o tbkUser Transbank responderá con un status code 404 (Not Found) y el sdk retornará una excepción.
+        En caso de éxito Transbank responderá con un status code 204 (No Content) y el sdk no retornará true. En el caso de no encontrarse el userName o tbkUser Transbank responderá con un status code 404 (Not Found) y el sdk retornara una excepción.
     </div>
 </div>
 <br>

--- a/transbank-sdk-dotnet-core-rest-example/Views/oneclick_mall/delete.cshtml
+++ b/transbank-sdk-dotnet-core-rest-example/Views/oneclick_mall/delete.cshtml
@@ -35,12 +35,24 @@
             </pre>
         </div>
     </div><br>
-
-
+<div class="row">
+    <div class="col-6">
+        <pre>
+        <code class="language-json">
+                @ViewBag.Resp
+            </code>
+        </pre>
+    </div>
+    <div class="col-6">
+        <h4>Respuesta</h4>
+        En caso de éxito Transbank responderá con un status code 204 (No Content) y el sdk no retornará respuesta. En el caso de no encontrarse el userName o tbkUser Transbank responderá con un status code 404 (Not Found) y el sdk retornara una excepción.
+    </div>
+</div>
+<br>
     <div class="row">
         <div class="col-6">
-            <h4>Respuesta</h4>
-            En caso de éxito Transbank responderá con un status code 204 (No Content) y el sdk no retornará respuesta. En el caso de no encontrarse el userName o tbkUser Transbank responderá con un status code 404 (Not Found) y el sdk retornara una excepción.
+            <h4></h4>
+            
         </div>
     </div><br>
 

--- a/transbank-sdk-dotnet-core-rest-example/Views/oneclick_mall/delete.cshtml
+++ b/transbank-sdk-dotnet-core-rest-example/Views/oneclick_mall/delete.cshtml
@@ -39,7 +39,7 @@
     </div>
     <div class="col-6">
         <h4>Respuesta</h4>
-        En caso de éxito Transbank responderá con un status code 204 (No Content) y el sdk no retornará true. En el caso de no encontrarse el userName o tbkUser Transbank responderá con un status code 404 (Not Found) y el sdk retornara una excepción.
+        En caso de éxito Transbank responderá con un status code 204 (No Content) y el sdk retornará true. En el caso de no encontrarse el userName o tbkUser Transbank responderá con un status code 404 (Not Found) y el sdk retornara una excepción.
     </div>
 </div>
 <br>

--- a/transbank-sdk-dotnet-core-rest-example/Views/oneclick_mall/delete.cshtml
+++ b/transbank-sdk-dotnet-core-rest-example/Views/oneclick_mall/delete.cshtml
@@ -1,10 +1,4 @@
-﻿
-
-
-
-
-
-    @{Html.RenderPartial("~/Views/Shared/navbar-oneclick.cshtml");}
+﻿ @{Html.RenderPartial("~/Views/Shared/navbar-oneclick.cshtml");}
 
     <div class="row">
         <div class="col">
@@ -45,7 +39,7 @@
     </div>
     <div class="col-6">
         <h4>Respuesta</h4>
-        En caso de éxito Transbank responderá con un status code 204 (No Content) y el sdk no retornará respuesta. En el caso de no encontrarse el userName o tbkUser Transbank responderá con un status code 404 (Not Found) y el sdk retornara una excepción.
+        En caso de éxito Transbank responderá con un true. En el caso de no encontrarse el userName o tbkUser Transbank responderá con un status code 404 (Not Found) y el sdk retornará una excepción.
     </div>
 </div>
 <br>

--- a/transbank-sdk-dotnet-core-rest-example/Views/oneclick_mall_deferred/delete.cshtml
+++ b/transbank-sdk-dotnet-core-rest-example/Views/oneclick_mall_deferred/delete.cshtml
@@ -36,7 +36,19 @@
             </pre>
         </div>
     </div><br>
-
+<div class="row">
+    <div class="col-6">
+        <pre>
+        <code class="language-json">
+                @ViewBag.Resp
+            </code>
+        </pre>
+    </div>
+    <div class="col-6">
+        <h4>Respuesta</h4>
+        En caso de éxito Transbank responderá con un status code 204 (No Content) y el sdk no retornará respuesta. En el caso de no encontrarse el userName o tbkUser Transbank responderá con un status code 404 (Not Found) y el sdk retornara una excepción.
+    </div>
+</div>
 
     <div class="row">
         <div class="col-6">

--- a/transbank-sdk-dotnet-core-rest-example/Views/oneclick_mall_deferred/delete.cshtml
+++ b/transbank-sdk-dotnet-core-rest-example/Views/oneclick_mall_deferred/delete.cshtml
@@ -1,10 +1,4 @@
-﻿
-
-
-
-
-
-    @{Html.RenderPartial("~/Views/Shared/navbar-oneclick.cshtml");}
+﻿ @{Html.RenderPartial("~/Views/Shared/navbar-oneclick.cshtml");}
 
     <div class="row">
         <div class="col">
@@ -46,16 +40,11 @@
     </div>
     <div class="col-6">
         <h4>Respuesta</h4>
-        En caso de éxito Transbank responderá con un status code 204 (No Content) y el sdk no retornará respuesta. En el caso de no encontrarse el userName o tbkUser Transbank responderá con un status code 404 (Not Found) y el sdk retornara una excepción.
+        En caso de éxito Transbank responderá con un true. En el caso de no encontrarse el userName o tbkUser Transbank responderá con un status code 404 (Not Found) y el sdk retornará una excepción.
     </div>
 </div>
 
-    <div class="row">
-        <div class="col-6">
-            <h4>Respuesta</h4>
-            En caso de éxito Transbank responderá con un status code 204 (No Content) y el sdk no retornará respuesta. En el caso de no encontrarse el userName o tbkUser Transbank responderá con un status code 404 (Not Found) y el sdk retornara una excepción.
-        </div>
-    </div><br>
+   
 
     
 

--- a/transbank-sdk-dotnet-core-rest-example/Views/oneclick_mall_deferred/delete.cshtml
+++ b/transbank-sdk-dotnet-core-rest-example/Views/oneclick_mall_deferred/delete.cshtml
@@ -40,7 +40,7 @@
     </div>
     <div class="col-6">
         <h4>Respuesta</h4>
-        En caso de éxito Transbank responderá con un status code 204 (No Content) y el sdk no retornará true. En el caso de no encontrarse el userName o tbkUser Transbank responderá con un status code 404 (Not Found) y el sdk retornara una excepción.
+        En caso de éxito Transbank responderá con un status code 204 (No Content) y el sdk retornará true. En el caso de no encontrarse el userName o tbkUser Transbank responderá con un status code 404 (Not Found) y el sdk retornara una excepción.
     </div>
 </div>
 

--- a/transbank-sdk-dotnet-core-rest-example/Views/oneclick_mall_deferred/delete.cshtml
+++ b/transbank-sdk-dotnet-core-rest-example/Views/oneclick_mall_deferred/delete.cshtml
@@ -40,7 +40,7 @@
     </div>
     <div class="col-6">
         <h4>Respuesta</h4>
-        En caso de éxito Transbank responderá con un true. En el caso de no encontrarse el userName o tbkUser Transbank responderá con un status code 404 (Not Found) y el sdk retornará una excepción.
+        En caso de éxito Transbank responderá con un status code 204 (No Content) y el sdk no retornará true. En el caso de no encontrarse el userName o tbkUser Transbank responderá con un status code 404 (Not Found) y el sdk retornara una excepción.
     </div>
 </div>
 


### PR DESCRIPTION
Add response in "delete user" views.

This version includes the following changes:

- Added response in “delete user” view of Oneclick.

> Case of success
![Captura de Pantalla 2024-06-03 a la(s) 12 43 54](https://github.com/TransbankDevelopers/transbank-sdk-dotnet-core-webpay-rest-example/assets/99495937/5a81314b-2871-4933-939a-af26e3697eb0)

> Case of Failure
![Captura de Pantalla 2024-06-03 a la(s) 12 47 17](https://github.com/TransbankDevelopers/transbank-sdk-dotnet-core-webpay-rest-example/assets/99495937/ed44a2a0-7756-4928-81e9-c8bd707b2f9c)

- Added response in “delete user” view of Oneclick_deferred.

> Case of success
![Captura de Pantalla 2024-06-03 a la(s) 12 51 05](https://github.com/TransbankDevelopers/transbank-sdk-dotnet-core-webpay-rest-example/assets/99495937/90b87fe6-015b-41c9-b2cc-664408309ffc)

> Case of Failure
![Captura de Pantalla 2024-06-03 a la(s) 12 57 09](https://github.com/TransbankDevelopers/transbank-sdk-dotnet-core-webpay-rest-example/assets/99495937/3e2016ef-1d38-4902-aba7-4e32263691be)


