### PR TITLE
fix: change token_ws to token in full transactions functions for inconsistency

### DIFF
--- a/transbank-sdk-dotnet-core-rest-example/Controllers/TransaccionCompleta/FullTransactionController.cs
+++ b/transbank-sdk-dotnet-core-rest-example/Controllers/TransaccionCompleta/FullTransactionController.cs
@@ -62,7 +62,7 @@ namespace Controllers.TransaccionCompleta
 
             ViewBag.Response = response;
             ViewBag.Amount = response.Amount;
-            ViewBag.TokenWs = token;
+            ViewBag.Token = token;
             ViewBag.Resp = ToJson(response);
             ViewBag.StatusEndpoint = CreateUrl(ctrlName, "status");
             ViewBag.RefundEndpoint = CreateUrl(ctrlName, "refund");
@@ -80,7 +80,7 @@ namespace Controllers.TransaccionCompleta
 
             ViewBag.Response = response;
             ViewBag.Amount = response.Amount;
-            ViewBag.TokenWs = token;
+            ViewBag.Token = token;
             ViewBag.Resp = ToJson(response);
             ViewBag.StatusEndpoint = CreateUrl(ctrlName, "status");
             ViewBag.RefundEndpoint = CreateUrl(ctrlName, "refund");
@@ -95,7 +95,7 @@ namespace Controllers.TransaccionCompleta
             var response = tx.Installments(token, installments);
 
             ViewBag.Response = response;
-            ViewBag.token = token;
+            ViewBag.Token = token;
             ViewBag.id_query_installments = response.IdQueryInstallments;
             ViewBag.Resp = ToJson(response);
 
@@ -105,10 +105,10 @@ namespace Controllers.TransaccionCompleta
             return View($"{viewBase}installments.cshtml");
         }
         [Route("status")]
-        public ActionResult status(String token_ws)
+        public ActionResult Status(String token)
         {
 
-            var response = tx.Status(token_ws);
+            var response = tx.Status(token);
 
             ViewBag.Response = response;
             var originalResponse = response.OriginalResponse;
@@ -118,10 +118,10 @@ namespace Controllers.TransaccionCompleta
             return View($"{viewBase}status.cshtml");
         }
         [Route("refund")]
-        public ActionResult Refund(String token_ws, Decimal amount)
+        public ActionResult Refund(String token, Decimal amount)
         {
 
-            var response = tx.Refund(token_ws, amount);
+            var response = tx.Refund(token, amount);
 
             ViewBag.Response = response;
             ViewBag.Resp = ToJson(response);

--- a/transbank-sdk-dotnet-core-rest-example/Controllers/TransaccionCompleta/FullTransactionDeferredController.cs
+++ b/transbank-sdk-dotnet-core-rest-example/Controllers/TransaccionCompleta/FullTransactionDeferredController.cs
@@ -63,7 +63,7 @@ namespace Controllers.TransaccionCompleta
 
             ViewBag.Response = response;
             ViewBag.Amount = response.Amount;
-            ViewBag.TokenWs = token;
+            ViewBag.Token = token;
             ViewBag.BuyOrder = response.BuyOrder;
             ViewBag.AuthorizationCode = response.AuthorizationCode;
             ViewBag.Resp = ToJson(response);
@@ -88,7 +88,7 @@ namespace Controllers.TransaccionCompleta
 
             ViewBag.Response = response;
             ViewBag.Amount = response.Amount;
-            ViewBag.TokenWs = token;
+            ViewBag.Token = token;
             ViewBag.AuthorizationCode = response.AuthorizationCode;
             ViewBag.BuyOrder = response.BuyOrder;
             ViewBag.Resp = ToJson(response);
@@ -110,7 +110,7 @@ namespace Controllers.TransaccionCompleta
             var response = tx.Installments(token, installments);
 
             ViewBag.Response = response;
-            ViewBag.TokenWs = token;
+            ViewBag.Token = token;
             ViewBag.id_query_installments = response.IdQueryInstallments;
             ViewBag.Resp = ToJson(response);
 
@@ -125,14 +125,14 @@ namespace Controllers.TransaccionCompleta
             return View($"{viewBase}installments.cshtml");
         }
         [Route("capture")]
-        public ActionResult Capture(String token_ws, String buy_order, String authorization_code, Decimal amount)
+        public ActionResult Capture(String token, String buy_order, String authorization_code, Decimal amount)
         {
 
-            var response = tx.Capture(token_ws, buy_order, authorization_code, amount);
+            var response = tx.Capture(token, buy_order, authorization_code, amount);
 
             ViewBag.Response = response;
             ViewBag.Resp = ToJson(response);
-            ViewBag.TokenWs = token_ws;
+            ViewBag.Token = token;
             ViewBag.Amount = amount;
             ViewBag.AuthorizationCode = authorization_code;
             ViewBag.BuyOrder = buy_order;
@@ -148,10 +148,10 @@ namespace Controllers.TransaccionCompleta
             return View($"{viewBase}capture.cshtml");
         }
         [Route("status")]
-        public ActionResult status(String token_ws)
+        public ActionResult Status(String token)
         {
 
-            var response = tx.Status(token_ws);
+            var response = tx.Status(token);
 
             ViewBag.Response = response;
             var originalResponse = response.OriginalResponse;
@@ -161,14 +161,14 @@ namespace Controllers.TransaccionCompleta
             return View($"{viewBase}status.cshtml");
         }
         [Route("refund")]
-        public ActionResult Refund(String token_ws, Decimal amount)
+        public ActionResult Refund(String token, Decimal amount)
         {
 
-            var response = tx.Refund(token_ws, amount);
+            var response = tx.Refund(token, amount);
 
             ViewBag.Response = response;
             ViewBag.Resp = ToJson(response);
-            ViewBag.TokenWs = token_ws;
+            ViewBag.Token = token;
 
             return View($"{viewBase}refund.cshtml");
         }

--- a/transbank-sdk-dotnet-core-rest-example/Controllers/TransaccionCompleta/MallFullTransactionController.cs
+++ b/transbank-sdk-dotnet-core-rest-example/Controllers/TransaccionCompleta/MallFullTransactionController.cs
@@ -92,7 +92,7 @@ namespace Controllers.TransaccionCompleta
             ViewBag.ChildCommerceCode = child_commerce_code;
             ViewBag.ChildBuyOrder = child_buy_order;
             ViewBag.Amount = 1000;
-            ViewBag.TokenWs = token;
+            ViewBag.Token = token;
 
             ViewBag.StatusEndpoint = CreateUrl(ctrlName, "status");
             ViewBag.RefundEndpoint = CreateUrl(ctrlName, "refund");
@@ -120,7 +120,7 @@ namespace Controllers.TransaccionCompleta
 
             ViewBag.Response = response;
             ViewBag.Amount = 1000;
-            ViewBag.TokenWs = token;
+            ViewBag.Token = token;
             ViewBag.Resp = ToJson(response);
             ViewBag.ChildCommerceCode = child_commerce_code;
             ViewBag.ChildBuyOrder = child_buy_order;
@@ -158,10 +158,10 @@ namespace Controllers.TransaccionCompleta
             return View($"{viewBase}installments.cshtml");
         }
         [Route("status")]
-        public ActionResult status(String token_ws)
+        public ActionResult status(String token)
         {
 
-            var response = tx.Status(token_ws);
+            var response = tx.Status(token);
 
             ViewBag.Response = response;
             var originalResponse = response.OriginalResponse;
@@ -171,14 +171,14 @@ namespace Controllers.TransaccionCompleta
             return View($"{viewBase}status.cshtml");
         }
         [Route("refund")]
-        public ActionResult Refund(String token_ws, int amount, String child_commerce_code, String child_buy_order)
+        public ActionResult Refund(String token, int amount, String child_commerce_code, String child_buy_order)
         {
 
-            var response = tx.Refund(token_ws, child_buy_order, child_commerce_code, amount);
+            var response = tx.Refund(token, child_buy_order, child_commerce_code, amount);
 
             ViewBag.Response = response;
             ViewBag.Resp = ToJson(response);
-            ViewBag.TokenWs = token_ws;
+            ViewBag.Token = token;
 
             return View($"{viewBase}refund.cshtml");
         }

--- a/transbank-sdk-dotnet-core-rest-example/Controllers/TransaccionCompleta/MallFullTransactionDeferredController.cs
+++ b/transbank-sdk-dotnet-core-rest-example/Controllers/TransaccionCompleta/MallFullTransactionDeferredController.cs
@@ -87,7 +87,7 @@ namespace Controllers.TransaccionCompleta
             ViewBag.ChildCommerceCode = child_commerce_code;
             ViewBag.ChildBuyOrder = child_buy_order;
             ViewBag.Amount = 1000;
-            ViewBag.TokenWs = token;
+            ViewBag.Token = token;
             ViewBag.BuyOrder = response.BuyOrder;
             ViewBag.AuthorizationCode = response.Details[0].AuthorizationCode;
 
@@ -126,10 +126,10 @@ namespace Controllers.TransaccionCompleta
             return View($"{viewBase}capture.cshtml");
         }
         [Route("status")]
-        public ActionResult status(String token_ws)
+        public ActionResult Status(String token)
         {
 
-            var response = tx.Status(token_ws);
+            var response = tx.Status(token);
 
             ViewBag.Response = response;
             var originalResponse = response.OriginalResponse;
@@ -139,14 +139,14 @@ namespace Controllers.TransaccionCompleta
             return View($"{viewBase}status.cshtml");
         }
         [Route("refund")]
-        public ActionResult Refund(String token_ws, String buy_order, String child_buy_order, String child_commerce_code, String authorization_code, int amount)
+        public ActionResult Refund(String token, String buy_order, String child_buy_order, String child_commerce_code, String authorization_code, int amount)
         {
 
-            var response = tx.Refund(token_ws, child_buy_order, child_commerce_code, amount);
+            var response = tx.Refund(token, child_buy_order, child_commerce_code, amount);
 
             ViewBag.Response = response;
             ViewBag.Resp = ToJson(response);
-            ViewBag.TokenWs = token_ws;
+            ViewBag.Token = token;
 
             return View($"{viewBase}refund.cshtml");
         }

--- a/transbank-sdk-dotnet-core-rest-example/Views/Shared/tx-mall-status-refund.cshtml
+++ b/transbank-sdk-dotnet-core-rest-example/Views/Shared/tx-mall-status-refund.cshtml
@@ -6,7 +6,7 @@
 <div class="row">
     <div class="col-6">
         <form action="@ViewBag.StatusEndpoint" method="POST">
-          <input type="hidden" name="token_ws" value="@ViewBag.TokenWs">
+          <input type="hidden" name="token" value="@ViewBag.Token">
           <button type="submit" class="btn btn-primary">CONSULTAR ESTADO</button>
         </form>
     </div>
@@ -15,7 +15,7 @@
           <div class="card-body">Formulario de reembolso
             <h6 class="card-title">Formulario de reembolso</h6>
             <form action="@ViewBag.RefundEndpoint" method="POST">
-              <input type="hidden" name="token_ws" value="@ViewBag.TokenWs">
+              <input type="hidden" name="token" value="@ViewBag.Token">
               <div class="mb-3">
                   <label for="child_commerce_code" class="form-label">Código de tienda hija</label>
                   <input type="text" class="form-control" name="child_commerce_code" value="@ViewBag.ChildCommerceCode">

--- a/transbank-sdk-dotnet-core-rest-example/Views/Shared/tx-status-refund.cshtml
+++ b/transbank-sdk-dotnet-core-rest-example/Views/Shared/tx-status-refund.cshtml
@@ -6,7 +6,7 @@
 <div class="row">
     <div class="col-6">
         <form action="@ViewBag.StatusEndpoint" method="POST">
-          <input type="hidden" name="token_ws" value="@ViewBag.TokenWs">
+          <input type="hidden" name="token" value="@ViewBag.Token">
           <button type="submit" class="btn btn-primary">CONSULTAR ESTADO</button>
         </form>
     </div>
@@ -15,7 +15,7 @@
           <div class="card-body">
             <h6 class="card-title">Formulario de reembolso</h6>
             <form action="@ViewBag.RefundEndpoint" method="POST">
-              <input type="hidden" name="token_ws" value="@ViewBag.TokenWs">
+              <input type="hidden" name="token" value="@ViewBag.Token">
               <div class="mb-3">
                 <label for="amount" class="form-label">Monto a reembolsar</label>
                 <input type="text" class="form-control" name="amount" value="@ViewBag.Amount">

--- a/transbank-sdk-dotnet-core-rest-example/Views/deferred_common/deferred-options.cshtml
+++ b/transbank-sdk-dotnet-core-rest-example/Views/deferred_common/deferred-options.cshtml
@@ -1,5 +1,5 @@
 ﻿<form action="@ViewBag.CaptureEndpoint" method="POST">
-    <input type="hidden" name="token_ws" value="@ViewBag.TokenWs">
+    <input type="hidden" name="token" value="@ViewBag.Token">
     <input type="hidden" name="buy_order" value="@ViewBag.BuyOrder">
     <input type="hidden" name="child_buy_order" value="@ViewBag.ChildBuyOrder">
     <input type="hidden" name="child_commerce_code" value="@ViewBag.ChildCommerceCode">

--- a/transbank-sdk-dotnet-core-rest-example/Views/transaccion_completa_deferred/installments.cshtml
+++ b/transbank-sdk-dotnet-core-rest-example/Views/transaccion_completa_deferred/installments.cshtml
@@ -76,7 +76,7 @@
                 <form action="@ViewBag.CommitEndpoint" method="POST">
                   <div class="mb-3">
                       <label for="token" class="form-label">Token</label>
-                      <input type="text" class="form-control" id="token" name="token" value="@ViewBag.TokenWs">
+                      <input type="text" class="form-control" id="token" name="token" value="@ViewBag.Token">
                   </div>
                   <div class="mb-3">
                     <label for="id_query_installments" class="form-label">ID de consulta de cuotas (Opcional)</label>


### PR DESCRIPTION
Problem Description:

In the project, there is an inconsistency in the variable name representing the token. Some files of full transactions use token_ws, while other use token. This discrepancy cause confusion and errors in refund, capture and status function of the controllers.

This PR includes the following changes:

Controllers:
- Change var token_ws to token in functions of FullTransactionControllers.
- Change var token_ws to token in functions of FullTransactionDeferredControllers.
- Change var token_ws to token in functions of MallFullTransactionControllers.
- Change var token_ws to token in functions of MallFullTransactionDeferredControllers.
Views:
- Change input name token_ws to token and change input value ViewBag.TokenWs to Viewbag.Token in tx-mall-status-refund.cshtml, this view is shred with the mall transactions controllers.
- Change input name token_ws to token and change input value ViewBag.TokenWs to Viewbag.Token in tx-status-refund.cshtml, this view is shred with the transactions controllers.
- Change input name token_ws to token and change input value ViewBag.TokenWs to Viewbag.Token in deferred-options cshtml, this view is shred with the transactions deferred controllers.
- Change input value ViewBag.TokenWs to Viewbag.Token in installments.cshtml of mall transaction deferred.


 